### PR TITLE
Fixing a Simple Typo

### DIFF
--- a/ui/app/views/directives/markdown-editor.html
+++ b/ui/app/views/directives/markdown-editor.html
@@ -6,7 +6,7 @@
         <a href ng-click="preview()">Preview</a>
     </li>
    <li class="pull-right">
-        <a href="http://daringfireball.net/projects/markdown/syntax" target="_blank"><i class="fa fa-question-circle"></i> Mardown Reference</a>
+        <a href="http://daringfireball.net/projects/markdown/syntax" target="_blank"><i class="fa fa-question-circle"></i> Markdown Reference</a>
     </li>
 </ul>
 <div class="vpad10" ng-show="edition">

--- a/ui/app/views/directives/updatable-text.html
+++ b/ui/app/views/directives/updatable-text.html
@@ -33,7 +33,7 @@
                 <i class="text-danger glyphicon glyphicon-remove"></i>
             </span>
             <a class="pull-right" href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank">
-                <i class="fa fa-question-circle"></i> Mardown Reference</a>
+                <i class="fa fa-question-circle"></i> Markdown Reference</a>
         </div>
     </div>
 </span>

--- a/ui/app/views/partials/case/case.tasks.item.html
+++ b/ui/app/views/partials/case/case.tasks.item.html
@@ -83,7 +83,7 @@
         <div class="row" ng-show="adding">
             <div class="col-md-12">
                 <div class="clearfix">
-                    <a class="pull-right" href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank"><i class="fa fa-question-circle"></i> Mardown Reference</a>
+                    <a class="pull-right" href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank"><i class="fa fa-question-circle"></i> Markdown Reference</a>
                 </div>
                 <!-- <markdown-editor edition="isEditMode" content="newLog.message" placeholder="New log"></markdown-editor> -->
                 <textarea name="content" class="content-box" markdown-editor="{'iconlibrary': 'fa', addExtraButtons: true, resize: 'vertical'}" rows="10" ng-model="newLog.message"></textarea>


### PR DESCRIPTION
Just corrected a few instances of "Mardown" to "Markdown."