### PR TITLE
Fix "Run from Docker"

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
                     <div class="btns">
                         <a class="btn btn-lg btn-cta-secondary" href="https://github.com/CERT-BDF/TheHive/wiki/Docker-guide" target="_blank">Run from Docker</a>
                     </div>
-                    <pre>$ docker --rm --publish 127.0.0.1:9000:9000 --volume /opt/thehive/data:/data certbdf/thehive:latest</pre>
+                    <pre>$ docker run --rm --publish 127.0.0.1:9000:9000 --volume /opt/thehive/data:/data certbdf/thehive:latest</pre>
                 </div>
 
                 <hr class="separator">


### PR DESCRIPTION
It works better with `docker run` 

```
% docker --rm --publish 127.0.0.1:9000:9000 --volume /home/yoyo/projects/thehive:/data certbdf/thehive:latest    
flag provided but not defined: --rm
See 'docker --help'.
```

```
% docker run --rm --publish 127.0.0.1:9000:9000 --volume /home/yoyo/projects/thehive:/data certbdf/thehive:latest
[2016-11-09 15:26:38,266][WARN ][bootstrap                ] unable to install syscall filter: seccomp unavailable: your kernel is buggy and you should upgrade
[2016-11-09 15:26:39,465][INFO ][node                     ] [Dream Weaver] version[2.3.5], pid[7], build[90f439f/2016-07-27T10:36:52Z]
[2016-11-09 15:26:39,466][INFO ][node                     ] [Dream Weaver] initializing ...
[2016-11-09 15:26:41,858][INFO ][plugins                  ] [Dream Weaver] modules [reindex, lang-expression, lang-groovy], plugins [], sites []
....
```

```
% docker version                                                                                                                                                                                                                 125 ↵
Client:
 Version:      1.12.3
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   6b644ec
 Built:        Wed Oct 26 22:01:48 2016
 OS/Arch:      linux/amd64

Server:
 Version:      1.12.3
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   6b644ec
 Built:        Wed Oct 26 22:01:48 2016
 OS/Arch:      linux/amd64
```

