### PR TITLE
New analyzer to check URL categories

### DIFF
--- a/analyzers/URLCategory/report/success_long.html
+++ b/analyzers/URLCategory/report/success_long.html
@@ -1,0 +1,18 @@
+<div class="panel panel-info">
+    <div class="panel-heading">
+        URL Categories of <strong>{{artifact.data}}</strong>
+    </div>
+    <div class="panel-body">
+	<dl class="dl-horizontal" ng-if="content.fortinet_category">
+                <dt>Fortinet URL Category: </dt>
+                <dd class="wrap">{{content.fortinet_category}}&nbsp; 
+			<i class="fa fa-search"></i>
+                        <a ng-href="http://www.fortiguard.com/iprep?data={{artifact.data}}&lookup=Lookup" target="_blank">
+                                View Full Report</a>
+			<i class="fa fa-recycle"></i>    
+			<a ng-href="http://www.fortiguard.com/iprep_form?data={{artifact.data}}" target="_blank">
+				Request Recategorization</a> 
+		</dd>
+        </dl>
+    </div>
+</div>

--- a/analyzers/URLCategory/report/success_short.html
+++ b/analyzers/URLCategory/report/success_short.html
@@ -1,0 +1,4 @@
+<span class="label label-info">
+	URLCat:
+	<span ng-if="content.fortinet_category">{{content.fortinet_category}}&nbsp;</span>
+</span>

--- a/analyzers/URLCategory/urlcategory.py
+++ b/analyzers/URLCategory/urlcategory.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# encoding: utf-8
+import sys
+import os
+import json
+import codecs
+import time
+import re
+import requests
+
+if sys.stdout.encoding != 'UTF-8':
+	if sys.version_info.major == 3:
+		sys.stdout = codecs.getwriter('utf-8')(sys.stdout.buffer, 'strict')
+	else:
+		sys.stdout = codecs.getwriter('utf-8')(sys.stdout, 'strict')
+if sys.stderr.encoding != 'UTF-8':
+	if sys.version_info.major == 3:
+		sys.stderr = codecs.getwriter('utf-8')(sys.stderr.buffer, 'strict')
+	else:
+		sys.stderr = codecs.getwriter('utf-8')(sys.stderr, 'strict')
+
+# load artifact
+artifact = json.load(sys.stdin)
+
+def error(message):
+	print('{{"errorMessage":"{}"}}'.format(message))
+	sys.exit(1)
+
+def get_param(name, default=None, message=None, current=artifact):
+	if isinstance(name, str):
+		name = name.split('.')
+	if len(name) == 0:
+		return current
+	else:
+		value = current.get(name[0])
+		if value == None:
+			if message != None:
+				error(message)
+			else:
+				return default
+		else:
+			return get_param(name[1:], default, message, value)
+
+def debug(msg):
+	#print >> sys.stderr, msg
+	pass
+
+def fortinet_category(data):
+	debug('>> fortinet_category ' + str(data))
+	pattern = re.compile("(?:Category: )([\w\s]+)")
+	baseurl = 'http://www.fortiguard.com/iprep?data='
+	tailurl = '&lookup=Lookup'
+	url = baseurl + data + tailurl
+	r = requests.get(url)
+	category_match = re.search(pattern, r.content, flags=0)
+	return category_match.group(1)
+
+http_proxy     = get_param('config.proxy.http')
+https_proxy    = get_param('config.proxy.https')
+max_tlp        = get_param('config.max_tlp', 1)
+tlp            = get_param('tlp', 2) # amber by default
+data_type      = get_param('dataType', None, 'Missing dataType field')
+service        = get_param('config.service', None, 'Service parameter is missing')
+
+# run  only if TLP condition is met
+if tlp > max_tlp:
+	error('Error with TLP value ; see max_tlp in config or tlp value in input data')
+
+# setup proxy
+if http_proxy != None:
+	os.environ['http_proxy'] = http_proxy
+if https_proxy != None:
+	os.environ['https_proxy'] = https_proxy
+
+if service == 'query':
+	if data_type == 'url' or data_type == 'domain':
+		data = get_param('data', None, 'Data is missing')
+	        json.dump({
+                        'fortinet_category': fortinet_category(data)
+                	}, sys.stdout, ensure_ascii=False)
+	else:
+		error('Invalid data type')
+else:
+	error('Invalid service')
+

--- a/analyzers/URLCategory_1.0.json
+++ b/analyzers/URLCategory_1.0.json
@@ -1,0 +1,13 @@
+{
+	"name": "URLCategory",
+	"version": "1.0",
+	"report": "URLCategory/report",
+	"description": "URL Category query: checks the category of a specific URL or domain",
+	"dataTypeList": ["url", "domain"],
+	"baseConfig" : "URLCategory",
+	"config": {
+		"service": "query",
+		"max_tlp": 10
+	},
+	"command": "URLCategory/urlcategory.py"
+}


### PR DESCRIPTION
Go easy on me, this is my first pull request _(ever)_. 

This is a _very_ simple analyzer that checks a `domain` or `url` artifact against [Fortinet's website category service](http://www.fortiguard.com/webfilter). I initially wrote it to also check Bluecoat, but then soon found that Bluecoat started using Captchas after so many queries so I pulled that chunk out. 

I will add additional services as I can find ones that permit automated query. 

I imagine this could be useful for SOCs that utilize a proxy, NGFW or UTM that filters URLs using the databases queried by this analyzer (_currently only Fortinet_). If an analyst see thats Fortigate classifies the site as `Malicious Websites` ([example](
http://www.fortiguard.com/iprep?data=off.ncongruousric.bid&lookup=Lookup)), then no action need be taken assuming the network is defended by a Fortinet firewall and (hopefully) automatically blocking URLs of that category. **Analyst Time Saved!** 

On the other hand, if a malicious site is being miscategorized or is otherwise `Not Rated` ([example](http://www.fortiguard.com/iprep?data=neshehertz.com)), the analyzer report provides a quick link to "Request Recategorization" (see below). **Threat intel shared!**

Small Report Example
![](https://i.imgur.com/eThFVYl.png)
Large Report Example
![](https://i.imgur.com/92XHz6M.png)
