### PR TITLE
New analyzer to query PhishTank for a URL

### DIFF
--- a/analyzers/PhishTank_CheckURL/phishtank_checkurl.py
+++ b/analyzers/PhishTank_CheckURL/phishtank_checkurl.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# encoding: utf-8
+import sys
+import os
+import json
+import codecs
+import time
+import re
+import requests
+
+if sys.stdout.encoding != 'UTF-8':
+	if sys.version_info.major == 3:
+		sys.stdout = codecs.getwriter('utf-8')(sys.stdout.buffer, 'strict')
+	else:
+		sys.stdout = codecs.getwriter('utf-8')(sys.stdout, 'strict')
+if sys.stderr.encoding != 'UTF-8':
+	if sys.version_info.major == 3:
+		sys.stderr = codecs.getwriter('utf-8')(sys.stderr.buffer, 'strict')
+	else:
+		sys.stderr = codecs.getwriter('utf-8')(sys.stderr, 'strict')
+
+# load artifact
+artifact = json.load(sys.stdin)
+
+def error(message):
+	print('{{"errorMessage":"{}"}}'.format(message))
+	sys.exit(1)
+
+def get_param(name, default=None, message=None, current=artifact):
+	if isinstance(name, str):
+		name = name.split('.')
+	if len(name) == 0:
+		return current
+	else:
+		value = current.get(name[0])
+		if value == None:
+			if message != None:
+				error(message)
+			else:
+				return default
+		else:
+			return get_param(name[1:], default, message, value)
+
+def debug(msg):
+	print >> sys.stderr, msg
+	pass
+
+http_proxy     = get_param('config.proxy.http')
+https_proxy    = get_param('config.proxy.https')
+max_tlp        = get_param('config.max_tlp', 1)
+tlp            = get_param('tlp', 2) # amber by default
+data_type      = get_param('dataType', None, 'Missing dataType field')
+service        = get_param('config.service', None, 'Service parameter is missing')
+phishtank_key  = get_param('config.key', None, 'Missing PhishTank API key')
+
+def phishtank_checkurl(data):
+	debug('>> phishtank_checkurl ' + str(data))
+	url = 'http://checkurl.phishtank.com/checkurl/'
+	postdata = {'url': data, 'format':'json','app_key': phishtank_key}
+	r = requests.post(url, data=postdata)
+	return json.loads(r.content)
+
+# run  only if TLP condition is met
+if tlp > max_tlp:
+	error('Error with TLP value ; see max_tlp in config or tlp value in input data')
+
+# setup proxy
+if http_proxy != None:
+	os.environ['http_proxy'] = http_proxy
+if https_proxy != None:
+	os.environ['https_proxy'] = https_proxy
+
+if service == 'query':
+	if data_type == 'url':
+		data = get_param('data', None, 'Data is missing')
+		r = phishtank_checkurl(data)
+		if "success" in r['meta']['status']:
+			if r['results']['in_database']:
+				if "verified" in r['results']:
+					json.dump({
+						'in_database': r['results']['in_database'],
+						'phish_detail_page': r['results']['phish_detail_page'],
+						'verified': r['results']['verified'],
+						'verified_at': r['results']['verified_at']
+					}, sys.stdout, ensure_ascii=False)
+				else:
+					json.dump({
+							'in_database': r['results']['in_database'],
+							'phish_detail_page': r['results']['phish_detail_page']
+					}, sys.stdout, ensure_ascii=False)
+			else:
+				json.dump({
+				 'in_database': 'False'
+				}, sys.stdout, ensure_ascii=False)
+		else:
+			json.dump({
+					'errortext': r['errortext']
+			}, sys.stdout, ensure_ascii=False)
+	else:
+			error('Invalid data type')
+else:
+		error('Invalid service')

--- a/analyzers/PhishTank_CheckURL/report/success_long.html
+++ b/analyzers/PhishTank_CheckURL/report/success_long.html
@@ -1,0 +1,35 @@
+<div class="panel panel-info">
+    <div class="panel-heading">
+        PhishTank Report for <strong>{{artifact.data}}</strong>
+    </div>
+    <div class="panel-body">
+	<dl class="dl-horizontal" ng-if="content.errortext">
+                <dt>ERROR: </dt>
+                <dd class="wrap">{{content.errortext}}&nbsp;</dd>
+        </dl>
+	<dl class="dl-horizontal" ng-if="content.in_database">
+                <dt>In database: </dt>
+                <dd class="wrap">{{content.in_database}}&nbsp;</dd>
+	</dl>
+        <dl class="dl-horizontal" ng-if="content.verified">
+                <dt>Verified: </dt>
+                <dd class="wrap">{{content.verified}}&nbsp;</dd>
+        </dl>
+        <dl class="dl-horizontal" ng-if="content.verified_at">
+                <dt>Verified at: </dt>
+                <dd class="wrap">{{content.verified_at}}&nbsp;</dd>
+        </dl>
+	<dl class="dl-horizontal" ng-if="content.phish_detail_page">
+                <dt>Phish Detail Page: </dt>
+		<dd class="wrap">
+			<a ng-href="{{content.phish_detail_page}}" target="_blank">{{content.phish_detail_page}}</a>
+		</dd>
+       	</dl>
+	<dl class="dl-horizontal" ng-if="content.in_database === 'False'">
+		<dt>Submit to PhishTank: </dat>
+		<dd class="wrap">
+			<i class="fa fa-bullhorn"></i><a ng-href="mailto:phish@phishtank.com?subject=New Phishing Site Found&Body=PhishTank,%0dPlease take notice of this phishing site recently observed by our analysts.%0d%0d{{artifact.data}}"> Click here to submit this site to PhishTank</a>
+		</dd>
+	</dl>
+    </div>
+</div>

--- a/analyzers/PhishTank_CheckURL/report/success_short.html
+++ b/analyzers/PhishTank_CheckURL/report/success_short.html
@@ -1,0 +1,4 @@
+<span class="label" ng-class="{'false':'label-info', 'true':'label-danger'}[content.in_database]">
+	PhishTank:
+	<span ng-if="content">{{content.in_database}}&nbsp;</span>
+</span>

--- a/analyzers/PhishTank_CheckURL_1.0.json
+++ b/analyzers/PhishTank_CheckURL_1.0.json
@@ -1,0 +1,13 @@
+{
+	"name": "PhishTank_CheckURL",
+	"version": "1.0",
+	"report": "PhishTank_CheckURL/report",
+	"description": "Check URL against PhishTank to determine if it's a verified phishing site",
+	"dataTypeList": ["url"],
+	"baseConfig" : "PhishTank_CheckURL",
+	"config": {
+		"service": "query",
+		"max_tlp": 10
+	},
+	"command": "PhishTank_CheckURL/phishtank_checkurl.py"
+}


### PR DESCRIPTION
Another simple one that queries URL item types to determine if they are in the PhishTank database yet. 

If a URL is already in the PhishTank database, we add a short report to the artifact title.
![](https://i.imgur.com/P04sirC.png)
If it is not, we do not add anything to the artifact title.

Example long report of URL found in PhishTank
![](https://i.imgur.com/k11vreC.png)

<hr>
Great example of a false negative where a true phishing site is not in the PhishTank database yet. Context clues come from the URLQuery category validating the site as `Phishing`. 

![](https://i.imgur.com/WNw27rm.png)
( Notice that there is no PhishTank short report on the title because the site is not currently in the PhishTank database, see long report below )

![](https://i.imgur.com/YuteD6Z.png)

Also notice that if a site is not already listed on PhishTank, an option appears to `Click here to submit this site to PhishTank` which generates a pre-written email to PhishTank to report the phishing site.

![](https://i.imgur.com/3Pkukhz.png)

<hr>

We're even trying to account for unknowns and error situations by passing through the API error text in the event of a bad API call... This great example came from an analyst accidentally inputting an already defanged URL into TheHive (which is obviously unnecessary.)

![](https://i.imgur.com/kW3wZHp.png)