### PR TITLE
AlienVault OTX Analyzer

### DIFF
--- a/analyzers/OTXQuery/otxquery.py
+++ b/analyzers/OTXQuery/otxquery.py
@@ -43,7 +43,7 @@ def get_param(name, default=None, message=None, current=artifact):
 			return get_param(name[1:], default, message, value)
 
 def debug(msg):
-	print >> sys.stderr, msg
+	#print >> sys.stderr, msg
 	pass
 
 http_proxy     = get_param('config.proxy.http')

--- a/analyzers/OTXQuery/otxquery.py
+++ b/analyzers/OTXQuery/otxquery.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+# encoding: utf-8
+import sys
+import os
+import json
+import codecs
+#from threading import Timer
+import time
+import requests
+import urllib
+
+if sys.stdout.encoding != 'UTF-8':
+	if sys.version_info.major == 3:
+		sys.stdout = codecs.getwriter('utf-8')(sys.stdout.buffer, 'strict')
+	else:
+		sys.stdout = codecs.getwriter('utf-8')(sys.stdout, 'strict')
+if sys.stderr.encoding != 'UTF-8':
+	if sys.version_info.major == 3:
+		sys.stderr = codecs.getwriter('utf-8')(sys.stderr.buffer, 'strict')
+	else:
+		sys.stderr = codecs.getwriter('utf-8')(sys.stderr, 'strict')
+
+# load artifact
+artifact = json.load(sys.stdin)
+
+def error(message):
+	print('{{"errorMessage":"{}"}}'.format(message))
+	sys.exit(1)
+
+def get_param(name, default=None, message=None, current=artifact):
+	if isinstance(name, str):
+		name = name.split('.')
+	if len(name) == 0:
+		return current
+	else:
+		value = current.get(name[0])
+		if value == None:
+			if message != None:
+				error(message)
+			else:
+				return default
+		else:
+			return get_param(name[1:], default, message, value)
+
+def debug(msg):
+	print >> sys.stderr, msg
+	pass
+
+http_proxy     = get_param('config.proxy.http')
+https_proxy    = get_param('config.proxy.https')
+max_tlp        = get_param('config.max_tlp', 1)
+tlp            = get_param('tlp', 2) # amber by default
+data_type      = get_param('dataType', None, 'Missing dataType field')
+service        = get_param('config.service', None, 'Service parameter is missing')
+otx_key        = get_param('config.key', None, 'Missing OTX API key')
+
+def OTX_Query_IP(data):
+	debug('>> OTX_Query_IP ' + str(data))
+	baseurl = "https://otx.alienvault.com:443/api/v1/indicators/IPv4/%s/" % data
+	headers = {'X-OTX-API-KEY': otx_key, 'Accept':'application/json'}
+	sections = ['general','reputation','geo','malware','url_list','passive_dns']
+	IP_={}
+	try:
+		for section in sections:
+			queryurl = baseurl + section
+			IP_[section] = json.loads(requests.get(queryurl, headers=headers).content)
+	except:
+		error('API Error! Please verify data type is correct.')
+
+	json.dump({
+		'pulse_count': IP_['general']['pulse_info']['count'],
+		'pulses': IP_['general']['pulse_info']['pulses'],
+		'whois': IP_['general']['whois'],
+		'continent_code': IP_['geo']['continent_code'],
+		'country_code': IP_['geo']['country_code'],
+		'country_name': IP_['geo']['country_name'],
+		'city': IP_['geo']['city'],
+		'longitude': IP_['general']['longitude'],
+		'latitude': IP_['general']['latitude'],
+		'asn': IP_['geo']['asn'],
+		'malware_samples': IP_['malware']['result'],
+		'url_list': IP_['url_list']['url_list'],
+		'passive_dns': IP_['passive_dns']['passive_dns']
+	}, sys.stdout, ensure_ascii=False)
+
+
+def OTX_Query_Domain(data):
+	debug('>> OTX_Query_Domain ' + str(data))
+	baseurl = "https://otx.alienvault.com:443/api/v1/indicators/domain/%s/" % data
+	headers = {'X-OTX-API-KEY': otx_key, 'Accept':'application/json'}
+	sections = ['general','geo','malware','url_list','passive_dns']
+	IP_={}
+	try:
+		for section in sections:
+			queryurl = baseurl + section
+			IP_[section] = json.loads(requests.get(queryurl, headers=headers).content)
+	except:
+		error('API Error! Please verify data type is correct.')
+
+	json.dump({
+		'pulse_count': IP_['general']['pulse_info']['count'],
+		'pulses': IP_['general']['pulse_info']['pulses'],
+		'whois': IP_['general']['whois'],
+		'continent_code': IP_['geo']['continent_code'],
+		'country_code': IP_['geo']['country_code'],
+		'country_name': IP_['geo']['country_name'],
+		'city': IP_['geo']['city'],
+		'asn': IP_['geo']['asn'],
+		'malware_samples': IP_['malware']['result'],
+		'url_list': IP_['url_list']['url_list'],
+		'passive_dns': IP_['passive_dns']['passive_dns']
+	}, sys.stdout, ensure_ascii=False)
+
+
+def OTX_Query_File(data):
+	debug('>> OTX_Query_File ' + str(data))
+	baseurl = "https://otx.alienvault.com:443/api/v1/indicators/file/%s/" % data
+	headers = {'X-OTX-API-KEY': otx_key, 'Accept':'application/json'}
+	sections = ['general','analysis']
+	IP_={}
+	try:
+		for section in sections:
+			queryurl = baseurl + section
+			IP_[section] = json.loads(requests.get(queryurl, headers=headers).content)
+	except:
+		error('API Error! Please verify data type is correct.')
+
+	
+	if IP_['analysis']['analysis']: # file has been analyzed before
+		json.dump({
+			'pulse_count': IP_['general']['pulse_info']['count'],
+			'pulses': IP_['general']['pulse_info']['pulses'],
+			'malware': IP_['analysis']['malware'],
+			'page_type': IP_['analysis']['page_type'],
+			'sha1': IP_['analysis']['analysis']['info']['results']['sha1'],
+			'sha256': IP_['analysis']['analysis']['info']['results']['sha256'],
+			'md5': IP_['analysis']['analysis']['info']['results']['md5'],
+			'file_class': IP_['analysis']['analysis']['info']['results']['file_class'],
+			'file_type': IP_['analysis']['analysis']['info']['results']['file_type'],
+			'filesize': IP_['analysis']['analysis']['info']['results']['filesize'],
+			'ssdeep': IP_['analysis']['analysis']['info']['results']['ssdeep']
+		}, sys.stdout, ensure_ascii=False)
+	else: # file has not been analyzed before
+		json.dump({
+			'errortext': 'File has not previously been analyzed by OTX!',
+			'pulse_count': IP_['general']['pulse_info']['count'],
+			'pulses': IP_['general']['pulse_info']['pulses']
+		}, sys.stdout, ensure_ascii=False)
+
+
+def OTX_Query_URL(data):
+	debug('>> OTX_Query_URL ' + str(data))
+	data = urllib.quote_plus(data) # urlencode the URL that we are searching for
+	baseurl = "https://otx.alienvault.com:443/api/v1/indicators/url/%s/" % data
+	headers = {'X-OTX-API-KEY': otx_key, 'Accept':'application/json'}
+	sections = ['general','url_list']
+	IP_={}
+	try:
+		for section in sections:
+			queryurl = baseurl + section
+			IP_[section] = json.loads(requests.get(queryurl, headers=headers).content)
+	except:
+		error('API Error! Please verify data type is correct.')
+
+	json.dump({
+		'pulse_count': IP_['general']['pulse_info']['count'],
+		'pulses': IP_['general']['pulse_info']['pulses'],
+		'alexa': IP_['general']['alexa'],
+		'whois': IP_['general']['whois'],
+		'url_list': IP_['url_list']['url_list']
+	}, sys.stdout, ensure_ascii=False)
+
+
+# run  only if TLP condition is met
+if tlp > max_tlp:
+	error('Error with TLP value ; see max_tlp in config or tlp value in input data')
+	
+# setup proxy
+if http_proxy != None:
+	os.environ['http_proxy'] = http_proxy
+if https_proxy != None:
+	os.environ['https_proxy'] = https_proxy
+
+
+if service == 'query':
+	if data_type == 'file':
+		hashes = get_param('attachment.hashes', None, 'Hash is missing')
+		# find SHA256 hash
+		hash = next(h for h in hashes if len(h) == 64)
+		OTX_Query_File(hash)
+	elif data_type == 'url':
+		data = get_param('data', None, 'Data is missing')
+		OTX_Query_URL(data)
+	elif data_type == 'domain':
+		data = get_param('data', None, 'Data is missing')
+		OTX_Query_Domain(data)
+	elif data_type == 'ip':
+		data = get_param('data', None, 'Data is missing')
+		OTX_Query_IP(data)
+	elif data_type == 'hash':
+		data = get_param('data', None, 'Data is missing')
+		OTX_Query_File(data)
+	else:
+		error('Invalid data type')
+else:
+	error('Invalid service')

--- a/analyzers/OTXQuery/report/success_long.html
+++ b/analyzers/OTXQuery/report/success_long.html
@@ -17,7 +17,6 @@
 		<dl class="dl-horizontal" ng-if="content.pulse_count > 0">
 			<dt>Related Pulses: </dt>
 			<dd class="wrap">
-			<!-- {{content.pulses}} -->
 			<div ng-repeat="pulse in ::content.pulses | limitTo:4">
 				<strong>Name: </strong><a ng-href="https://otx.alienvault.com/pulse/{{::pulse.id}}/" target="_blank">{{::pulse.name}}</a><br/>
 				<strong>Author: </strong>{{::pulse.author.username}}<br/>
@@ -26,7 +25,6 @@
 				<strong>Subscribed: </strong>{{::pulse.is_subscribing}} <br/>
 				<strong>Industries: </strong>{{::pulse.industries}} <br/>
 				<strong>Indicators: </strong>{{::pulse.indicator_count}}
-				<!-- need to make this more robust -->
 				<hr>
 			</div>
 			</dd>
@@ -42,7 +40,6 @@
 		<dl class="dl-horizontal" ng-if="content.malware_samples not === 'No samples found'">
 			<dt>Malware Samples: </dt>			
 			<dd class="wrap">
-			<!-- for debugging {{content.malware_samples}} -->
 			<div ng-repeat="sample in ::content.malware_samples | limitTo:20">
 				{{::sample.sample}}
 			</div>
@@ -97,16 +94,12 @@
 		<dl class="dl-horizontal" ng-if="content.url_list.length > 0">
 			<dt>Related URLs: </dt>
 			<dd class="wrap">
-				<!-- for debugging
-				{{content.url_list}} 
-				-->
 			<div ng-repeat="url in ::content.url_list | limitTo:20">
 				<strong>URL: </strong>{{::url.url}} <br/>
 				<strong>Date: </strong>{{::url.date}} <br/>
 				<strong>HTTP Code: </strong>{{::url.httpcode}} <br/>
 				<strong>IP: </strong>{{::url.result.urlworker.ip}}
 				<hr>
-				<!-- need to make this more robust -->
 			</div>
 			</dd>
 		</dl>
@@ -114,9 +107,6 @@
 		<dl class="dl-horizontal" ng-if="content.passive_dns.length > 2">
 			<dt>Passive DNS: </dt>
 			<dd class="wrap">
-				<!--
-				{{content.passive_dns}}
-				-->
 			<div ng-repeat="dns in ::content.passive_dns | limitTo:20">
 				<strong>Hostname: </strong>{{::dns.hostname}} <br/>
 				<strong>IP: </strong>{{::dns.address}} <br/>

--- a/analyzers/OTXQuery/report/success_long.html
+++ b/analyzers/OTXQuery/report/success_long.html
@@ -1,0 +1,165 @@
+<div class="panel panel-info">
+	<div class="panel-heading">
+		OTX Report
+	</div>
+	<div class="panel-body">
+
+		<dl class="dl-horizontal" ng-if="content.errortext">
+			<dt><i class="fa fa-warning"></i> ERROR: </dt>
+			<dd class="wrap">{{content.errortext}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal">
+			<dt>Related Pulses Found: </dt>
+			<dd class="wrap">{{content.pulse_count}}</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.pulse_count > 0">
+			<dt>Related Pulses: </dt>
+			<dd class="wrap">
+			<!-- {{content.pulses}} -->
+			<div ng-repeat="pulse in ::content.pulses | limitTo:4">
+				<strong>Name: </strong><a ng-href="https://otx.alienvault.com/pulse/{{::pulse.id}}/" target="_blank">{{::pulse.name}}</a><br/>
+				<strong>Author: </strong>{{::pulse.author.username}}<br/>
+				<strong>Modified: </strong>{{::pulse.modified_text}} @ {{::pulse.modified}} <br/>
+				<strong>Subscribers: </strong>{{::pulse.subscriber_count}} <br/>
+				<strong>Subscribed: </strong>{{::pulse.is_subscribing}} <br/>
+				<strong>Industries: </strong>{{::pulse.industries}} <br/>
+				<strong>Indicators: </strong>{{::pulse.indicator_count}}
+				<!-- need to make this more robust -->
+				<hr>
+			</div>
+			</dd>
+		</dl>
+
+		<dl class="dl-horizontal">
+			<dt>Submit Pulse: </dt>
+			<dd class="wrap">
+				<i class="fa fa-bullhorn"></i> <a ng-href="https://otx.alienvault.com/pulse/create/" target="_blank">Create a Pulse</a>&nbsp;
+			</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.malware_samples not === 'No samples found'">
+			<dt>Malware Samples: </dt>			
+			<dd class="wrap">
+			<!-- for debugging {{content.malware_samples}} -->
+			<div ng-repeat="sample in ::content.malware_samples | limitTo:20">
+				{{::sample.sample}}
+			</div>
+			</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.malware.length > 0">
+			<dt>Malware: </dt>
+			<dd class="wrap">{{content.malware}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.sha1.length > 0">
+			<dt>SHA1: </dt>
+			<dd class="wrap">{{content.sha1}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.sha256.length > 0">
+			<dt>SHA256: </dt>
+			<dd class="wrap">{{content.sha256}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.md5.length > 0">
+			<dt>MD5: </dt>
+			<dd class="wrap">{{content.md5}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.page_type">
+			<dt>Page Type: </dt>
+			<dd class="wrap">{{content.page_type}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.file_class">
+			<dt>File Class: </dt>
+			<dd class="wrap">{{content.file_class}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.file_type">
+			<dt>File Type: </dt>
+			<dd class="wrap">{{content.file_type}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.filesize">
+			<dt>File Size: </dt>
+			<dd class="wrap">{{content.filesize}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.ssdeep">
+			<dt>SSDEEP: </dt>
+			<dd class="wrap">{{content.ssdeep}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.url_list.length > 0">
+			<dt>Related URLs: </dt>
+			<dd class="wrap">
+				<!-- for debugging
+				{{content.url_list}} 
+				-->
+			<div ng-repeat="url in ::content.url_list | limitTo:20">
+				<strong>URL: </strong>{{::url.url}} <br/>
+				<strong>Date: </strong>{{::url.date}} <br/>
+				<strong>HTTP Code: </strong>{{::url.httpcode}} <br/>
+				<strong>IP: </strong>{{::url.result.urlworker.ip}}
+				<hr>
+				<!-- need to make this more robust -->
+			</div>
+			</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.passive_dns.length > 2">
+			<dt>Passive DNS: </dt>
+			<dd class="wrap">
+				<!--
+				{{content.passive_dns}}
+				-->
+			<div ng-repeat="dns in ::content.passive_dns | limitTo:20">
+				<strong>Hostname: </strong>{{::dns.hostname}} <br/>
+				<strong>IP: </strong>{{::dns.address}} <br/>
+				<strong>First/Last seen: </strong>{{::dns.first}} / {{::dns.last}} <br/>
+				<strong>Locale: </strong>{{::dns.flag_title}} 
+				<hr>
+			</div>
+			</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.whois">
+			<dt>Whois: </dt>
+			<dd class="wrap">
+				<i class="fa fa-search"></i> <a ng-href="{{content.whois}}" target="_blank">Whois Query</a>&nbsp;
+			</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.alexa">
+			<dt>Alexa: </dt>
+			<dd class="wrap">
+				<i class="fa fa-search"></i> <a ng-href="{{content.alexa}}" target="_blank">Alexa Report</a>&nbsp;
+			</dd>
+		</dl>		
+
+		<dl class="dl-horizontal" ng-if="content.city">
+			<dt>City: </dt>
+			<dd class="wrap">{{content.city}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.country_code">
+			<dt>Country Code: </dt>
+			<dd class="wrap">{{content.country_code}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.country_name">
+			<dt>Country: </dt>
+			<dd class="wrap">{{content.country_name}}&nbsp;</dd>
+		</dl>
+
+		<dl class="dl-horizontal" ng-if="content.asn">
+			<dt>ASN: </dt>
+			<dd class="wrap">{{content.asn}}&nbsp;</dd>
+		</dl>
+
+	</div>
+</div>

--- a/analyzers/OTXQuery/report/success_short.html
+++ b/analyzers/OTXQuery/report/success_short.html
@@ -1,0 +1,4 @@
+<span class="label" ng-class="{'false':'label-info', 'true':'label-danger'}[content.pulse_count > 0]">
+	OTX: 
+	<span>Pulses({{content.pulse_count}})&nbsp;</span>
+</span>

--- a/analyzers/OTXQuery_1.0.json
+++ b/analyzers/OTXQuery_1.0.json
@@ -1,0 +1,13 @@
+{
+	"name": "OTXQuery",
+	"version": "1.0",
+	"report": "OTXQuery/report",
+	"description": "Query AlienVault OTX for IPs, Domains, URLs, or File Hashes",
+	"dataTypeList": ["url", "domain", "file", "hash", "ip"],
+	"baseConfig" : "OTXQuery",
+	"config": {
+		"service": "query",
+		"max_tlp": 10
+	},
+	"command": "OTXQuery/otxquery.py"
+}


### PR DESCRIPTION
Slightly more involved analyzer to query AlienVault OTX for related Pulses as well as indicator enrichment. 

Can analyze `ip`,  `domain`, `url`, and `file`/`hash`. Adds a short report that reveals how many related Pulses exist for the observable. 

I feel like I might've overcomplicated in Python, but it's best I could do. If anyone has any pointers or improvements, please let me know. I am certain the reports could be done better, but the relevant info is displayed when present.

A free [OTX API key](https://otx.alienvault.com/settings/) will need to be added to `application.conf`
```
analyzer {
  # Directory that holds analyzers
  path = analyzers
  # Analyzer configuration
  config {
    OTXQuery {
	key="<api key>"
    }
  }
}
```

### Sample short reports...

#### An observable with one or more matching OTX Pulses
![](https://i.imgur.com/c9iYc2O.png)
#### And with no matching Pulses
![](https://i.imgur.com/MPYW4uK.png)


### Some sample long reports...
#### A file/hash query that matched an existing OTX Pulse
![](https://i.imgur.com/AJbSYzJ.png)

#### A URL query that returned other related URLs
![](https://i.imgur.com/swaZudu.pnghttps://i.imgur.com/swaZudu.png)

#### A file/hash query with no Pulses, but analysis info
![](https://i.imgur.com/Khxj0Ab.png)

#### A domain query that returned passive DNS records
![](https://i.imgur.com/pD3BfqO.png)

### Basic error handling
![](https://i.imgur.com/5WRuOF1.png)